### PR TITLE
Use osg::maximum to be more consistent and avoid including <algorithm>

### DIFF
--- a/src/osgOcean/OceanTile.cpp
+++ b/src/osgOcean/OceanTile.cpp
@@ -318,7 +318,7 @@ void OceanTile::computeMaxDelta( void )
                     float delta = biLinearInterp(posX, posX+step, posY, posY+step, j, i);
                     delta -= getVertex(j, i).z();
                     delta = fabs(delta);
-                    deltaMax = std::max(deltaMax, delta);
+                    deltaMax = osg::maximum(deltaMax, delta);
                 }
             }
         }


### PR DESCRIPTION
Recent version of MSVC (2015) are stricter with the include and throw an error on the use of `std::max` without including the `<algorithm>` header file.
However, the OSG version of `maximum()` is already used in this file.