### PR TITLE
Port osgOcean to OSG 3.4.x - use osg/Version to keep backwards compatibility

### DIFF
--- a/include/osgOcean/GodRays
+++ b/include/osgOcean/GodRays
@@ -21,6 +21,7 @@
 #include <osg/Geometry>
 #include <osg/BlendFunc>
 #include <osg/Texture2D>
+#include <osg/Version>
 #include <osgDB/ReadFile>
 #include <osgUtil/CullVisitor>
 #include <string>
@@ -206,7 +207,11 @@ namespace osgOcean
 		public:
 			ComputeBoundsCallback( GodRays& rays );
 
+#if OSG_VERSION_GREATER_THAN(3,2,1)
+			virtual osg::BoundingBox computeBoundingBox(const osg::Drawable&) const;
+#else
 			virtual osg::BoundingBox computeBound(const osg::Drawable&) const;
+#endif
 		};
 	};
 }

--- a/include/osgOcean/GodRays
+++ b/include/osgOcean/GodRays
@@ -207,10 +207,10 @@ namespace osgOcean
 		public:
 			ComputeBoundsCallback( GodRays& rays );
 
-#if OSG_VERSION_GREATER_THAN(3,2,1)
-			virtual osg::BoundingBox computeBoundingBox(const osg::Drawable&) const;
+#if OSG_VERSION_LESS_THAN(3,3,2)
+                        virtual osg::BoundingBox computeBound(const osg::Drawable&) const;
 #else
-			virtual osg::BoundingBox computeBound(const osg::Drawable&) const;
+			virtual osg::BoundingBox computeBoundingBox(const osg::Drawable&) const;
 #endif
 		};
 	};

--- a/include/osgOcean/MipmapGeometryVBO
+++ b/include/osgOcean/MipmapGeometryVBO
@@ -17,6 +17,7 @@
 
 #pragma once
 #include <osg/Geometry>
+#include <osg/Version>
 #include <assert.h>
 
 namespace osgOcean
@@ -144,8 +145,11 @@ namespace osgOcean
         * Rather than use standard computeBound() this computes the bounding box
         * using the offset and the worldSize.
         */
+#if OSG_VERSION_GREATER_THAN(3,2,1)
+        osg::BoundingBox computeBoundingBox( void ) const;
+#else
         osg::BoundingBox computeBound( void ) const;
-
+#endif
         /** 
         * Set the tile offset for shader positioning.
         * Calls dirtyBound() on its parents and recomputes recomputes
@@ -164,7 +168,11 @@ namespace osgOcean
             }
             
             dirtyBound();
+#if OSG_VERSION_GREATER_THAN(3,2,1)
+            setBound( computeBoundingBox() );
+#else
             setBound( computeBound() );
+#endif
         }
 
         /** 

--- a/include/osgOcean/MipmapGeometryVBO
+++ b/include/osgOcean/MipmapGeometryVBO
@@ -145,10 +145,10 @@ namespace osgOcean
         * Rather than use standard computeBound() this computes the bounding box
         * using the offset and the worldSize.
         */
-#if OSG_VERSION_GREATER_THAN(3,2,1)
-        osg::BoundingBox computeBoundingBox( void ) const;
-#else
+#if OSG_VERSION_LESS_THAN(3,3,2)
         osg::BoundingBox computeBound( void ) const;
+#else
+        osg::BoundingBox computeBoundingBox( void ) const;
 #endif
         /** 
         * Set the tile offset for shader positioning.
@@ -168,10 +168,10 @@ namespace osgOcean
             }
             
             dirtyBound();
-#if OSG_VERSION_GREATER_THAN(3,2,1)
-            setBound( computeBoundingBox() );
-#else
+#if OSG_VERSION_LESS_THAN(3,3,2)
             setBound( computeBound() );
+#else
+            setBound( computeBoundingBox() );
 #endif
         }
 

--- a/src/osgOcean/GodRays.cpp
+++ b/src/osgOcean/GodRays.cpp
@@ -401,7 +401,11 @@ GodRays::ComputeBoundsCallback::ComputeBoundsCallback( GodRays& rays )
     :_rays(rays)
 {}
 
+#if OSG_VERSION_GREATER_THAN(3,2,1)
+osg::BoundingBox GodRays::ComputeBoundsCallback::computeBoundingBox(const osg::Drawable& draw) const
+#else
 osg::BoundingBox GodRays::ComputeBoundsCallback::computeBound(const osg::Drawable& draw) const
+#endif
 {
     GodRays::GodRayDataType* data = static_cast<GodRays::GodRayDataType*> (_rays.getUserData() );
 

--- a/src/osgOcean/GodRays.cpp
+++ b/src/osgOcean/GodRays.cpp
@@ -401,10 +401,10 @@ GodRays::ComputeBoundsCallback::ComputeBoundsCallback( GodRays& rays )
     :_rays(rays)
 {}
 
-#if OSG_VERSION_GREATER_THAN(3,2,1)
-osg::BoundingBox GodRays::ComputeBoundsCallback::computeBoundingBox(const osg::Drawable& draw) const
-#else
+#if OSG_VERSION_LESS_THAN(3,3,2)
 osg::BoundingBox GodRays::ComputeBoundsCallback::computeBound(const osg::Drawable& draw) const
+#else
+osg::BoundingBox GodRays::ComputeBoundsCallback::computeBoundingBox(const osg::Drawable& draw) const
 #endif
 {
     GodRays::GodRayDataType* data = static_cast<GodRays::GodRayDataType*> (_rays.getUserData() );

--- a/src/osgOcean/MipmapGeometryVBO.cpp
+++ b/src/osgOcean/MipmapGeometryVBO.cpp
@@ -83,7 +83,11 @@ namespace osgOcean
     {
     }
 
+#if OSG_VERSION_GREATER_THAN(3,2,1)
+    osg::BoundingBox MipmapGeometryVBO::computeBoundingBox( void ) const 
+#else
     osg::BoundingBox MipmapGeometryVBO::computeBound( void ) const 
+#endif
     {
         osg::BoundingBox bb;
         

--- a/src/osgOcean/MipmapGeometryVBO.cpp
+++ b/src/osgOcean/MipmapGeometryVBO.cpp
@@ -83,10 +83,10 @@ namespace osgOcean
     {
     }
 
-#if OSG_VERSION_GREATER_THAN(3,2,1)
-    osg::BoundingBox MipmapGeometryVBO::computeBoundingBox( void ) const 
+#if OSG_VERSION_LESS_THAN(3,3,2)
+    osg::BoundingBox MipmapGeometryVBO::computeBound( void ) const
 #else
-    osg::BoundingBox MipmapGeometryVBO::computeBound( void ) const 
+    osg::BoundingBox MipmapGeometryVBO::computeBoundingBox( void ) const 
 #endif
     {
         osg::BoundingBox bb;

--- a/src/osgOcean/OceanScene.cpp
+++ b/src/osgOcean/OceanScene.cpp
@@ -881,7 +881,11 @@ void OceanScene::traverse( osg::NodeVisitor& nv )
 
                 bool surfaceVisible = _oceanSurface->isVisible(*cv, eyeAboveWater);
 
+#if OSG_VERSION_GREATER_THAN(3,3,2)
+                (*_oceanSurface->getCullCallback()).run(_oceanSurface.get(), &nv);
+#else
                 (*_oceanSurface->getCullCallback())(_oceanSurface.get(), &nv);
+#endif
 
                 preRenderCull(*cv, eyeAboveWater, surfaceVisible);     // reflections/refractions
                 

--- a/src/osgOcean/OceanScene.cpp
+++ b/src/osgOcean/OceanScene.cpp
@@ -881,10 +881,10 @@ void OceanScene::traverse( osg::NodeVisitor& nv )
 
                 bool surfaceVisible = _oceanSurface->isVisible(*cv, eyeAboveWater);
 
-#if OSG_VERSION_GREATER_THAN(3,3,2)
-                (*_oceanSurface->getCullCallback()).run(_oceanSurface.get(), &nv);
-#else
+#if OSG_VERSION_LESS_THAN(3,3,9)
                 (*_oceanSurface->getCullCallback())(_oceanSurface.get(), &nv);
+#else
+                (*_oceanSurface->getCullCallback()).run(_oceanSurface.get(), &nv);
 #endif
 
                 preRenderCull(*cv, eyeAboveWater, surfaceVisible);     // reflections/refractions

--- a/src/osgOcean/SiltEffect.cpp
+++ b/src/osgOcean/SiltEffect.cpp
@@ -26,8 +26,10 @@
 #include <osg/io_utils>
 #include <osg/Timer>
 #include <osg/Version>
+#include <osg/Geometry>
 
 using namespace osgOcean;
+using namespace osg;
 
 static float random(float min,float max) { return min + (max-min)*(float)rand()/(float)RAND_MAX; }
 
@@ -648,7 +650,14 @@ void SiltEffect::SiltDrawable::drawImplementation(osg::RenderInfo& renderInfo) c
 {
     if (!_geometry) return;
 
+#if OSG_VERSION_GREATER_THAN(3,0,0)
+    State& state = *renderInfo.getState();
+    unsigned int contextID = state.getContextID();
+    GLExtensions* extensions = state.get<GLExtensions>();
+    if (!extensions) return;
+#else
     const osg::Geometry::Extensions* extensions = osg::Geometry::getExtensions(renderInfo.getContextID(),true);
+#endif
 
     glPushMatrix();
 

--- a/src/osgOcean/SiltEffect.cpp
+++ b/src/osgOcean/SiltEffect.cpp
@@ -650,13 +650,13 @@ void SiltEffect::SiltDrawable::drawImplementation(osg::RenderInfo& renderInfo) c
 {
     if (!_geometry) return;
 
-#if OSG_VERSION_GREATER_THAN(3,0,0)
+#if OSG_VERSION_LESS_THAN(3,0,0)
+    const osg::Geometry::Extensions* extensions = osg::Geometry::getExtensions(renderInfo.getContextID(),true);
+#else
     State& state = *renderInfo.getState();
     unsigned int contextID = state.getContextID();
     GLExtensions* extensions = state.get<GLExtensions>();
     if (!extensions) return;
-#else
-    const osg::Geometry::Extensions* extensions = osg::Geometry::getExtensions(renderInfo.getContextID(),true);
 #endif
 
     glPushMatrix();


### PR DESCRIPTION
These changes make osgOcean work against OpenSceneGraph 3.4.1 and should preserve backwards compatibility. 